### PR TITLE
Fix typo on project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dokku provisioner
 
-[Dooku](https://dokku.com/) is a fantastic tool! According to their website, Dooku is an open-source PAAS alternative to Heroku that helps you build and manage the lifecycle of applications from building to scaling.
+[Dokku](https://dokku.com/) is a fantastic tool! According to their website, Dokku is an open-source PAAS alternative to Heroku that helps you build and manage the lifecycle of applications from building to scaling.
 
 In 2022, Heroku has [recently decided to discontinue the free plans](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq), which increased the number of people looking for free alternatives. That's where Dokku comes in, it provides everything Heroku offered, if you have a host to install it and if you are willing to learn how it works.
 

--- a/setup.rb
+++ b/setup.rb
@@ -81,7 +81,7 @@ if (instructions[:after_deploy].length > 0)
   puts ""
   puts "#{pastel.yellow.bold("AFTER THE DEPLOY")} \n"
   puts divider
-  puts "Once your code is on Dooku, you can run these commands:"
+  puts "Once your code is on Dokku, you can run these commands:"
   puts ""
   puts pastel.yellow(instructions[:after_deploy].join("\n"))
 end


### PR DESCRIPTION
The name of the server is Dokku, not Dooku. I am fixing the code and the documentation.