### PR TITLE
Set correct SSL command

### DIFF
--- a/models/dokku.rb
+++ b/models/dokku.rb
@@ -85,7 +85,7 @@ class Dokku
   def ssl_instructions
     commands = []
 
-    commands << "dokku config:set --no-restart #{@app} DOKKU_LETSENCRYPT_EMAIL=#{@email}"
+    commands << "dokku letsencrypt:set #{@app} email #{@email}"
     commands << "dokku letsencrypt:enable #{@app}"
     commands << "dokku letsencrypt:cron-job --add"
     commands << "dokku proxy:ports-set #{@app} http:80:5000 https:443:5000"


### PR DESCRIPTION
I tried to run the command to add an env var but Dokku complained and suggested this new way of setting the email. This is probably caused by a difference of versions from now and when I first created this project.