### PR TITLE
Remove unnecessary port-mapping command

### DIFF
--- a/models/dokku.rb
+++ b/models/dokku.rb
@@ -91,7 +91,6 @@ class Dokku
     commands << "dokku letsencrypt:set #{@app} email #{@email}"
     commands << "dokku letsencrypt:enable #{@app}"
     commands << "dokku letsencrypt:cron-job --add"
-    commands << "dokku proxy:ports-set #{@app} http:80:5000 https:443:5000"
 
     commands
   end


### PR DESCRIPTION
Let's encrypt `enable` command will already map the ports, there is no need to run this manually.