### PR TITLE
Fix error on letsencrypt command

### DIFF
--- a/models/questionnaire/questions/ssl.rb
+++ b/models/questionnaire/questions/ssl.rb
@@ -27,7 +27,7 @@ module Questionnaire
 
 
         data.ssl << Instruction.command("dokku letsencrypt:set #{app} email #{ssl_email}")
-        data.ssl << Instruction.command("dokku letsencrypt:enable #{@app}")
+        data.ssl << Instruction.command("dokku letsencrypt:enable #{app}")
       end
     end
   end

--- a/spec/models/questionnaire/questions/ssl_spec.rb
+++ b/spec/models/questionnaire/questions/ssl_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Questionnaire::Questions::SSL do
 
       expect(ssl_instructions[3]).to be_a(Instruction)
       expect(ssl_instructions[3].type).to eq(:command)
-      expect(ssl_instructions[3].text).to eq("dokku letsencrypt:enable #{@app}")
+      expect(ssl_instructions[3].text).to eq("dokku letsencrypt:enable #{app_name}")
     end
   end
 end


### PR DESCRIPTION
Letsencrypt command was not including the app name. It was printing: 
```
dokku letsencrypt:enable
```

instead of 

```
dokku letsencrypt:enable <app name>
```