### PR TITLE
Remove proxy command and fix tests

### DIFF
--- a/models/questionnaire/questions/app_name.rb
+++ b/models/questionnaire/questions/app_name.rb
@@ -18,7 +18,6 @@ module Questionnaire
 
         data.creating_app << Instruction.command("dokku apps:create #{app}")
         data.creating_app << Instruction.command("dokku git:initialize #{app}")
-        data.creating_app << Instruction.command("dokku proxy:ports-set #{app} http:80:5000")
       end
     end
   end

--- a/spec/models/dokku_provisioner_spec.rb
+++ b/spec/models/dokku_provisioner_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DokkuProvisioner do
     end
 
     it "returns the data" do
-      expect(provisioner.provision).to be_a(Data)
+      expect(provisioner.provision).to be_a(ProvisionData)
     end
 
     it "returns the data with the answers" do

--- a/spec/models/provision_data_spec.rb
+++ b/spec/models/provision_data_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "../../models/data"
+require_relative "../../models/provision_data"
 require_relative "../../models/instruction"
 
-RSpec.describe Data do
+RSpec.describe ProvisionData do
   let(:data) { described_class.new }
 
   describe "#add_answer" do

--- a/spec/models/questionnaire/question_spec.rb
+++ b/spec/models/questionnaire/question_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../../models/data"
+require_relative "../../../models/provision_data"
 require_relative "../../../models/questionnaire/question"
 
 RSpec.describe Questionnaire::Question do

--- a/spec/models/questionnaire/questions/app_name_spec.rb
+++ b/spec/models/questionnaire/questions/app_name_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/app_name"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::AppName do
   let(:app_name) { "my-app" }
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 
@@ -41,10 +41,6 @@ RSpec.describe Questionnaire::Questions::AppName do
       expect(creating_app_instructions[1]).to be_a(Instruction)
       expect(creating_app_instructions[1].type).to eq(:command)
       expect(creating_app_instructions[1].text).to eq("dokku git:initialize my-app")
-
-      expect(creating_app_instructions[2]).to be_a(Instruction)
-      expect(creating_app_instructions[2].type).to eq(:command)
-      expect(creating_app_instructions[2].text).to eq("dokku proxy:ports-set my-app http:80:5000")
     end
   end
 end

--- a/spec/models/questionnaire/questions/domain_spec.rb
+++ b/spec/models/questionnaire/questions/domain_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/domain"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::Domain do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/env_vars_spec.rb
+++ b/spec/models/questionnaire/questions/env_vars_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/env_vars"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::EnvVars do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/final_question_spec.rb
+++ b/spec/models/questionnaire/questions/final_question_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/final_question"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::FinalQuestion do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/postgresql_backup_spec.rb
+++ b/spec/models/questionnaire/questions/postgresql_backup_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/postgresql_backup"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::PostgresqlBackup do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/server_spec.rb
+++ b/spec/models/questionnaire/questions/server_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/server"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::Server do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/ssl_spec.rb
+++ b/spec/models/questionnaire/questions/ssl_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/ssl"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::SSL do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 

--- a/spec/models/questionnaire/questions/tools_spec.rb
+++ b/spec/models/questionnaire/questions/tools_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "../../../../models/data"
+require_relative "../../../../models/provision_data"
 require_relative "../../../../models/questionnaire/questions/tools"
 require "tty-prompt"
 
 RSpec.describe Questionnaire::Questions::Tools do
-  let(:data) { Data.new }
+  let(:data) { ProvisionData.new }
   let(:prompt) { instance_double(TTY::Prompt) }
   let(:question) { described_class.new(data: data) }
 


### PR DESCRIPTION
The script is providing a command that does not exist anymore:

```
dokku proxy:ports-set <APP NAME> http:80:5000
``` 

I am removing it and fixing all the tests. There was a renamed a while ago and the tests were not updated.