### PR TITLE
Remove command from destroy app section

### DIFF
--- a/models/questionnaire/questions/final_question.rb
+++ b/models/questionnaire/questions/final_question.rb
@@ -20,7 +20,6 @@ module Questionnaire
       def setup_instructions
         app = data.answers[:app]
 
-        data.removing_app << Instruction.command("dokku proxy:clear-config #{app}")
         data.removing_app << Instruction.command("dokku apps:destroy #{app}")
       end
 

--- a/spec/models/questionnaire/questions/final_question_spec.rb
+++ b/spec/models/questionnaire/questions/final_question_spec.rb
@@ -43,11 +43,7 @@ RSpec.describe Questionnaire::Questions::FinalQuestion do
 
       expect(removing_app_instructions[1]).to be_a(Instruction)
       expect(removing_app_instructions[1].type).to eq(:command)
-      expect(removing_app_instructions[1].text).to eq("dokku proxy:clear-config #{app_name}")
-
-      expect(removing_app_instructions[2]).to be_a(Instruction)
-      expect(removing_app_instructions[2].type).to eq(:command)
-      expect(removing_app_instructions[2].text).to eq("dokku apps:destroy #{app_name}")
+      expect(removing_app_instructions[1].text).to eq("dokku apps:destroy #{app_name}")
     end
   end
 end


### PR DESCRIPTION
We have just removed a command from the setup instructions: https://github.com/arturcp/dokku-provisioner/pull/11

Now, it is time to remove another command from the destroy app section.