### PR TITLE
Allow names for servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The simplest way to start is by duplicating the .env.example file and renaming i
 .env example:
 
 ```
-DOKKU_SERVERS=127.0.0.1,my-host.com
+DOKKU_SERVERS=127.0.0.1|server 1,my-host.com|server 2
 AWS_ACCESS_KEY_ID=AAAAABBBBB1231401010
 AWS_SECRET_ACCESS_KEY=ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ```
 
-DOkKU_SERVERS is a special variable. If it is empty, you will see a placeholder on the instructions output. Otherwise, it can hold any number of IP addresses or hostnames, separated by commas. If you have more than one server, the script will ask you which one you want to use.
+DOkKU_SERVERS is a special variable. If it is empty, you will see a placeholder on the instructions output. Otherwise, it can hold any number of IP address|hostname pairs, separated by commas. If you have more than one server, the script will ask you which one you want to use.

--- a/models/questionnaire/questions/server.rb
+++ b/models/questionnaire/questions/server.rb
@@ -9,8 +9,17 @@ module Questionnaire
 
       def ask
         if servers.length > 1
+          servers_hash = servers.each_with_object({}) do |server, hash|
+            ip, name = server.split("|", 2)
+            if name.nil? || name.empty?
+              hash[ip] = ip
+            else
+              hash[name] = ip
+            end
+          end
+
           server = prompt.select("To which server are you going to deploy your app?",
-            servers)
+            servers_hash)
         else
           server = servers.first || PLACEHOLDER
         end


### PR DESCRIPTION
Dokku provisioner accepts a list of IPs on the DOKKU_SERVERS env var, separated by commas. However, when we have multiple servers, it is hard to know which server is which only looking at the IP address. 

This change allows us to include a hostname on the list, using the format "IP|name". If no name is provided, we fallback to show the IP. It makes the setup a lot easier to use.

![image](https://github.com/user-attachments/assets/2c18f895-2809-400c-9912-8c7b7dfcece6)
